### PR TITLE
fix: resolve #7 — community features

### DIFF
--- a/cmd/feature/main.go
+++ b/cmd/feature/main.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/bketelsen/feature/internal/oci"
 	"github.com/bketelsen/feature/internal/options"
 	"github.com/charmbracelet/fang"
 	"github.com/charmbracelet/lipgloss"
@@ -58,38 +59,59 @@ func NewRootCommand() (*cobra.Command, *viper.Viper) {
 		Short: "Install devcontainer features",
 		Args:  cobra.MinimumNArgs(1),
 		Long:  "Install devcontainer features on the host system.",
-		Example: `  # Install nodejs
+		Example: `  # Install nodejs (built-in)
   feature node
 
-  # Install Go
-  feature go`,
+  # Install Go (built-in)
+  feature go
+
+  # Install a community feature from an OCI registry
+  feature ghcr.io/devcontainers-extra/features/go-task:1`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := checkRootUser(cmd); err != nil {
 				return err
 			}
 			featureRoot, _ := cmd.Flags().GetString("featureRoot")
 			featureRoot = expandPath(featureRoot)
-			if err := ensureRepo(cmd, featureRoot); err != nil {
-				return err
-			}
 
 			slog.Info("Feature root", "path", featureRoot)
-			// check if the featureRoot exists
-			if _, err := os.Stat(featureRoot); os.IsNotExist(err) {
-				// create the featureRoot
-				if err := os.MkdirAll(featureRoot, 0o755); err != nil {
+
+			var featureDir string
+			var opts options.FeatureOptions
+
+			if oci.IsOCIRef(args[0]) {
+				// OCI community feature
+				ref, err := oci.ParseFeatureRef(args[0])
+				if err != nil {
+					return err
+				}
+				updateRepo, _ := cmd.Flags().GetBool("updateRepo")
+				cacheDir := filepath.Join(featureRoot+"-oci", ref.Registry, ref.Namespace, ref.Name, ref.Tag)
+				featureDir, err = oci.PullFeature(cmd.Context(), ref, cacheDir, updateRepo)
+				if err != nil {
+					return err
+				}
+				opts, err = options.GetOptionsForPath(featureDir)
+				if err != nil {
+					return err
+				}
+			} else {
+				// Built-in feature
+				if err := ensureRepo(cmd, featureRoot); err != nil {
+					return err
+				}
+				featureDir = filepath.Join(featureRoot, "src", args[0])
+				var err error
+				opts, err = options.GetOptionsForFeature(featureRoot, args[0])
+				if err != nil {
+					return err
+				}
+				if err := ensureCommonUtils(cmd, featureRoot); err != nil {
 					return err
 				}
 			}
 
-			opts, err := options.GetOptionsForFeature(featureRoot, args[0])
-			if err != nil {
-				return err
-			}
-			if err := ensureCommonUtils(cmd, featureRoot); err != nil {
-				return err
-			}
-			if err := installFeature(cmd, featureRoot, args[0]); err != nil {
+			if err := installFeature(cmd, featureDir); err != nil {
 				return err
 			}
 			if err := updateEnvironment(cmd, opts); err != nil {

--- a/cmd/feature/root.go
+++ b/cmd/feature/root.go
@@ -71,12 +71,12 @@ func ensureCommonUtils(_ *cobra.Command, featureRoot string) error {
 	return nil
 }
 
-func installFeature(_ *cobra.Command, featureRoot, feature string) error {
+func installFeature(_ *cobra.Command, featureDir string) error {
 	fmt.Println("Installing requested feature, please wait...")
 
-	featureInstallPath := filepath.Join(featureRoot, "src", feature, "install.sh")
+	featureInstallPath := filepath.Join(featureDir, "install.sh")
 	if _, err := os.Stat(featureInstallPath); os.IsNotExist(err) {
-		return fmt.Errorf("feature %s does not have an install script", feature)
+		return fmt.Errorf("feature at %s does not have an install script", featureDir)
 	}
 	command := "bash"
 	args := []string{featureInstallPath}

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,11 @@ require (
 	github.com/charmbracelet/fang v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/muesli/termenv v0.16.0
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.20.1
 	go.uber.org/automaxprocs v1.6.0
+	oras.land/oras-go/v2 v2.6.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/muesli/mango-cobra v1.2.0 // indirect
 	github.com/muesli/mango-pflag v0.1.0 // indirect
 	github.com/muesli/roff v0.1.0 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,10 @@ github.com/muesli/roff v0.1.0 h1:YD0lalCotmYuF5HhZliKWlIx7IEhiXeSfq7hNjFqGF8=
 github.com/muesli/roff v0.1.0/go.mod h1:pjAHQM9hdUUwm/krAfrLGgJkXJ+YuhtsfZ42kieB2Ig=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
+github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -146,3 +150,5 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+oras.land/oras-go/v2 v2.6.0 h1:X4ELRsiGkrbeox69+9tzTu492FMUu7zJQW6eJU+I2oc=
+oras.land/oras-go/v2 v2.6.0/go.mod h1:magiQDfG6H1O9APp+rOsvCPcW1GD2MM7vgnKY0Y+u1o=

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -1,0 +1,224 @@
+// Package oci provides support for pulling devcontainer features from OCI registries.
+package oci
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"oras.land/oras-go/v2/registry/remote"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// FeatureRef represents a parsed OCI feature reference.
+type FeatureRef struct {
+	Registry  string // e.g., "ghcr.io"
+	Namespace string // e.g., "devcontainers-extra/features"
+	Name      string // e.g., "go-task"
+	Tag       string // e.g., "1" (default: "latest")
+}
+
+// Repository returns the full repository path (namespace/name).
+func (r FeatureRef) Repository() string {
+	return r.Namespace + "/" + r.Name
+}
+
+// IsOCIRef returns true if the argument looks like an OCI reference.
+// It checks whether the first path segment contains a dot, indicating a registry hostname.
+func IsOCIRef(arg string) bool {
+	firstSlash := strings.Index(arg, "/")
+	if firstSlash < 0 {
+		return false
+	}
+	return strings.Contains(arg[:firstSlash], ".")
+}
+
+// ParseFeatureRef parses an OCI feature reference string into its components.
+// Expected format: registry/namespace[/...]/name[:tag]
+// Examples:
+//
+//	ghcr.io/devcontainers/features/go:1
+//	ghcr.io/devcontainers-extra/features/go-task:latest
+func ParseFeatureRef(ref string) (FeatureRef, error) {
+	parts := strings.SplitN(ref, "/", 2)
+	if len(parts) < 2 || parts[1] == "" {
+		return FeatureRef{}, fmt.Errorf("invalid OCI feature reference %q: expected registry/namespace/name[:tag]", ref)
+	}
+
+	registry := parts[0]
+	rest := parts[1] // e.g., "devcontainers-extra/features/go-task:1"
+
+	// Split the remaining path into segments
+	segments := strings.Split(rest, "/")
+	if len(segments) < 2 {
+		return FeatureRef{}, fmt.Errorf("invalid OCI feature reference %q: need at least registry/namespace/name", ref)
+	}
+
+	// Last segment is name[:tag]
+	last := segments[len(segments)-1]
+	namespace := strings.Join(segments[:len(segments)-1], "/")
+
+	name := last
+	tag := "latest"
+	if colonIdx := strings.LastIndex(last, ":"); colonIdx >= 0 {
+		name = last[:colonIdx]
+		tag = last[colonIdx+1:]
+		if tag == "" {
+			tag = "latest"
+		}
+	}
+
+	if name == "" {
+		return FeatureRef{}, fmt.Errorf("invalid OCI feature reference %q: empty feature name", ref)
+	}
+
+	return FeatureRef{
+		Registry:  registry,
+		Namespace: namespace,
+		Name:      name,
+		Tag:       tag,
+	}, nil
+}
+
+// PullFeature pulls a devcontainer feature from an OCI registry and extracts it to cacheDir.
+// If the feature is already cached (install.sh exists) and forceUpdate is false, it returns
+// the cached path without re-downloading.
+func PullFeature(ctx context.Context, ref FeatureRef, cacheDir string, forceUpdate bool) (string, error) {
+	// Check cache
+	if !forceUpdate {
+		if _, err := os.Stat(filepath.Join(cacheDir, "install.sh")); err == nil {
+			return cacheDir, nil
+		}
+	}
+
+	// Clean cache dir for fresh pull
+	if err := os.RemoveAll(cacheDir); err != nil {
+		return "", fmt.Errorf("clearing cache directory: %w", err)
+	}
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return "", fmt.Errorf("creating cache directory: %w", err)
+	}
+
+	// Connect to registry
+	repo, err := remote.NewRepository(ref.Registry + "/" + ref.Repository())
+	if err != nil {
+		return "", fmt.Errorf("connecting to registry: %w", err)
+	}
+	// Use anonymous auth (sufficient for public registries)
+	repo.PlainHTTP = false
+
+	// Fetch the manifest
+	descriptor, rc, err := repo.FetchReference(ctx, ref.Tag)
+	if err != nil {
+		return "", fmt.Errorf("fetching manifest for %s:%s: %w (if this is a private registry, try 'docker login %s' first)", ref.Repository(), ref.Tag, err, ref.Registry)
+	}
+	defer rc.Close()
+
+	manifestBytes, err := io.ReadAll(rc)
+	if err != nil {
+		return "", fmt.Errorf("reading manifest: %w", err)
+	}
+
+	// Parse manifest to find the feature layer
+	var layerDesc ocispec.Descriptor
+	switch descriptor.MediaType {
+	case ocispec.MediaTypeImageManifest, "application/vnd.docker.distribution.manifest.v2+json":
+		var manifest ocispec.Manifest
+		if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+			return "", fmt.Errorf("parsing manifest: %w", err)
+		}
+		if len(manifest.Layers) == 0 {
+			return "", fmt.Errorf("OCI manifest for %s has no layers", ref.Repository())
+		}
+		// Prefer the devcontainer-specific media type, fall back to first layer
+		layerDesc = manifest.Layers[0]
+		for _, l := range manifest.Layers {
+			if l.MediaType == "application/vnd.devcontainers.layer.v1+tar" {
+				layerDesc = l
+				break
+			}
+		}
+	default:
+		return "", fmt.Errorf("unsupported manifest media type: %s", descriptor.MediaType)
+	}
+
+	// Fetch the layer blob
+	layerRC, err := repo.Fetch(ctx, layerDesc)
+	if err != nil {
+		return "", fmt.Errorf("fetching feature layer: %w", err)
+	}
+	defer layerRC.Close()
+
+	// Extract the tgz to cacheDir
+	if err := extractTGZ(layerRC, cacheDir); err != nil {
+		return "", fmt.Errorf("extracting feature archive: %w", err)
+	}
+
+	// Validate required files exist
+	for _, required := range []string{"install.sh", "devcontainer-feature.json"} {
+		if _, err := os.Stat(filepath.Join(cacheDir, required)); os.IsNotExist(err) {
+			return "", fmt.Errorf("extracted feature is missing required file %q", required)
+		}
+	}
+
+	// Ensure install.sh is executable
+	if err := os.Chmod(filepath.Join(cacheDir, "install.sh"), 0o755); err != nil {
+		return "", fmt.Errorf("making install.sh executable: %w", err)
+	}
+
+	return cacheDir, nil
+}
+
+// extractTGZ extracts a .tgz archive from r into targetDir with zip-slip prevention.
+func extractTGZ(r io.Reader, targetDir string) error {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("creating gzip reader: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading tar entry: %w", err)
+		}
+
+		// Zip-slip prevention: ensure the path stays within targetDir
+		target := filepath.Join(targetDir, filepath.Clean(header.Name))
+		if !strings.HasPrefix(target, filepath.Clean(targetDir)+string(os.PathSeparator)) && target != filepath.Clean(targetDir) {
+			return fmt.Errorf("tar entry %q attempts path traversal outside target directory", header.Name)
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode))
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(f, tr); err != nil {
+				f.Close()
+				return err
+			}
+			f.Close()
+		}
+	}
+	return nil
+}

--- a/internal/oci/oci_test.go
+++ b/internal/oci/oci_test.go
@@ -1,0 +1,103 @@
+package oci
+
+import (
+	"testing"
+)
+
+func TestIsOCIRef(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"ghcr.io/devcontainers/features/go:1", true},
+		{"ghcr.io/devcontainers-extra/features/go-task:latest", true},
+		{"docker.io/library/feature:1", true},
+		{"go", false},
+		{"node", false},
+		{"common-utils", false},
+		{"devcontainers/features/go", false}, // no dot in first segment
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := IsOCIRef(tt.input)
+			if got != tt.want {
+				t.Errorf("IsOCIRef(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseFeatureRef(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    FeatureRef
+		wantErr bool
+	}{
+		{
+			input: "ghcr.io/devcontainers/features/go:1",
+			want: FeatureRef{
+				Registry:  "ghcr.io",
+				Namespace: "devcontainers/features",
+				Name:      "go",
+				Tag:       "1",
+			},
+		},
+		{
+			input: "ghcr.io/devcontainers-extra/features/go-task:latest",
+			want: FeatureRef{
+				Registry:  "ghcr.io",
+				Namespace: "devcontainers-extra/features",
+				Name:      "go-task",
+				Tag:       "latest",
+			},
+		},
+		{
+			input: "ghcr.io/devcontainers/features/node",
+			want: FeatureRef{
+				Registry:  "ghcr.io",
+				Namespace: "devcontainers/features",
+				Name:      "node",
+				Tag:       "latest",
+			},
+		},
+		{
+			input: "docker.io/myorg/features/mytool:2.0",
+			want: FeatureRef{
+				Registry:  "docker.io",
+				Namespace: "myorg/features",
+				Name:      "mytool",
+				Tag:       "2.0",
+			},
+		},
+		{
+			input:   "ghcr.io/onlyone",
+			wantErr: true,
+		},
+		{
+			input:   "ghcr.io",
+			wantErr: true,
+		},
+		{
+			input:   "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseFeatureRef(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ParseFeatureRef(%q) expected error, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseFeatureRef(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseFeatureRef(%q) = %+v, want %+v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -40,32 +40,26 @@ type Customizations struct {
 	Vscode Vscode `json:"vscode"`
 }
 
-func GetOptionsForFeature(root, feature string) (FeatureOptions, error) {
-	// make sure the featureRoot exists
-	if _, err := os.Stat(root); os.IsNotExist(err) {
-		return FeatureOptions{}, err
-	}
-
-	// make sure the feature exists
-	if _, err := os.Stat(filepath.Join(root, "src", feature)); os.IsNotExist(err) {
-		return FeatureOptions{}, fmt.Errorf("feature %s not found", feature)
-	}
-
-	// Construct the path to the devcontainer-feature.json file
-	jsonPath := filepath.Join(root, "src", feature, "devcontainer-feature.json")
-	// Read the file
+// GetOptionsForPath reads and parses devcontainer-feature.json from an arbitrary directory.
+func GetOptionsForPath(featureDir string) (FeatureOptions, error) {
+	jsonPath := filepath.Join(featureDir, "devcontainer-feature.json")
 	bb, err := os.ReadFile(jsonPath)
 	if err != nil {
-		return FeatureOptions{}, err
+		return FeatureOptions{}, fmt.Errorf("feature metadata not found at %s: %w", jsonPath, err)
 	}
 
-	// Unmarshal the file into a FeatureOptions struct
 	var fo FeatureOptions
-	err = json.Unmarshal(bb, &fo)
-	if err != nil {
+	if err := json.Unmarshal(bb, &fo); err != nil {
 		return FeatureOptions{}, err
 	}
-
-	// Return the struct
 	return fo, nil
+}
+
+// GetOptionsForFeature reads and parses devcontainer-feature.json for a built-in feature.
+func GetOptionsForFeature(root, feature string) (FeatureOptions, error) {
+	featureDir := filepath.Join(root, "src", feature)
+	if _, err := os.Stat(featureDir); os.IsNotExist(err) {
+		return FeatureOptions{}, fmt.Errorf("feature %s not found", feature)
+	}
+	return GetOptionsForPath(featureDir)
 }

--- a/internal/options/options_test.go
+++ b/internal/options/options_test.go
@@ -1,0 +1,46 @@
+package options
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetOptionsForPath(t *testing.T) {
+	// Create a temp directory with a valid devcontainer-feature.json
+	dir := t.TempDir()
+	content := `{
+		"id": "test-feature",
+		"version": "1.0.0",
+		"name": "Test Feature",
+		"description": "A test feature",
+		"containerEnv": {
+			"FOO": "bar"
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(dir, "devcontainer-feature.json"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts, err := GetOptionsForPath(dir)
+	if err != nil {
+		t.Fatalf("GetOptionsForPath() error: %v", err)
+	}
+	if opts.ID != "test-feature" {
+		t.Errorf("ID = %q, want %q", opts.ID, "test-feature")
+	}
+	if opts.Version != "1.0.0" {
+		t.Errorf("Version = %q, want %q", opts.Version, "1.0.0")
+	}
+	if opts.ContainerEnv["FOO"] != "bar" {
+		t.Errorf("ContainerEnv[FOO] = %q, want %q", opts.ContainerEnv["FOO"], "bar")
+	}
+}
+
+func TestGetOptionsForPath_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	_, err := GetOptionsForPath(dir)
+	if err == nil {
+		t.Error("GetOptionsForPath() expected error for missing file, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
Add support for installing community devcontainer features directly from OCI registries (e.g., `ghcr.io/devcontainers-extra/features/go-task:1`), resolving #7. Previously, only built-in features from the cloned repo were supported. Now users can reference any public OCI-hosted feature by its registry path, and it will be pulled, cached, and installed using the same pipeline.

## Changes

- Add `internal/oci` package for parsing OCI feature references, pulling manifests/layers from registries via `oras-go`, and extracting `.tgz` archives with zip-slip protection
- Refactor `installFeature` to accept a feature directory path instead of root + name, unifying the install path for both built-in and community features
- Extract `GetOptionsForPath` in `internal/options` so feature metadata can be read from any directory, not just the built-in repo layout
- Update CLI to detect OCI references (hostname with dot in first path segment), route them through the OCI pull/cache flow, and skip the built-in repo clone step
- Add unit tests for OCI reference parsing and options path loading
- Add `oras-go/v2` and `opencontainers/image-spec` dependencies