### PR TITLE
docs: update documentation for feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code when working with code in this repository.
+
+## Documentation
+
+**update documentation** After any change to source code, update relevant documentation in CLAUDE.md, README.md and the yeti/ folder. A task is not complete without reviewing and updating relevant documentation.
+
+**yeti/ directory** The `yeti/` directory contains documentation written for AI consumption and context enhancement, not primarily for humans. Jobs like `doc-maintainer` and `issue-worker` instruct the AI to read `yeti/OVERVIEW.md` and related files for codebase context before performing tasks. Write content in this directory to be maximally useful to an AI agent understanding the codebase — detailed architecture, patterns, and decision rationale rather than user-facing guides.

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -89,8 +89,9 @@ Cobra for commands, Charmbracelet (lipgloss, fang) for terminal styling, `automa
 
 - **Build**: `task build` — compiles binary and generates docs
 - **Lint**: golangci-lint with strict ruleset (see `.golangci.yaml`)
-- **Release**: GoReleaser builds static Linux binaries (amd64, arm64), generates manpages and shell completions
-- **CI**: Woodpecker pipeline on push to main — builds and runs version check
+- **Release**: GoReleaser Pro builds static Linux binaries (amd64, arm64), generates manpages and shell completions
+- **CI (GitHub Actions)**: `go.yml` on push/PR to main — builds and tests; `release.yml` on tags — runs GoReleaser Pro
+- **CI (Woodpecker)**: Pipeline on push to main — builds and runs version check
 - **Versioning**: Semantic versioning via `svu`, conventional commits enforced
 
 See also:

--- a/yeti/build-release.md
+++ b/yeti/build-release.md
@@ -39,17 +39,35 @@ Go 1.24 target. Notable rules:
 
 ## GoReleaser (`.goreleaser.yaml`)
 
+- **Distribution**: GoReleaser Pro (`goreleaser-pro` in CI)
 - **Targets**: Linux amd64, arm64 only
 - **Static linking**: `CGO_ENABLED=0`
 - **ldflags**: Injects `version`, `commit`, `date`, `builtBy` into `main` package
-- **Archives**: tar.gz format, includes README, LICENSE, completions, manpages
+- **Pre-hooks**: `go mod tidy`, generates completions and manpages
+- **Archives**: tar.gz format, includes manpages
 - **Changelog**: GitHub API, grouped by type (Features, Security, Bug fixes, Docs), filters test/chore commits
+- **Announcements**: Bluesky integration configured (currently disabled)
+
+## CI — GitHub Actions (`.github/workflows/`)
+
+### `go.yml` — Build & Test
+Triggers on push/PR to `main`:
+1. Sets up Go 1.23
+2. `go build -v ./cmd/feature`
+3. `go test -v ./...`
+
+### `release.yml` — GoReleaser
+Triggers on tag push (`*`):
+1. Sets up Go (stable)
+2. Runs GoReleaser Pro (`goreleaser-pro` distribution, `~> v2`)
+3. Requires `GITHUB_TOKEN` and `GORELEASER_KEY` secrets
 
 ## CI — Woodpecker (`.woodpecker/workflow.yaml`)
 
 Triggers on push to `main`:
-1. `go build ./cmd/feature`
-2. `./feature --version`
+1. Uses `golang:1.24` image
+2. `go build ./cmd/feature`
+3. `./feature --version`
 
 ## Versioning (`.svu.yaml`)
 


### PR DESCRIPTION
## Summary

Updates AI-facing documentation to reflect the current build and release infrastructure. The project uses GoReleaser Pro (not the open-source edition) and has GitHub Actions workflows in addition to the existing Woodpecker CI pipeline — the docs now accurately describe both.

## Changes

- Added `CLAUDE.md` with guidance for AI agents on documentation maintenance and the purpose of the `yeti/` directory
- Updated `yeti/OVERVIEW.md` to distinguish between GitHub Actions and Woodpecker CI pipelines
- Updated `yeti/build-release.md` to document GoReleaser Pro distribution, pre-hooks, and Bluesky announcement config
- Added documentation for GitHub Actions workflows (`go.yml` build/test, `release.yml` GoReleaser)
- Corrected Woodpecker pipeline steps to match current `workflow.yaml`