### PR TITLE
refactor: Fix git pull running in wrong directory in ensureRepo

### DIFF
--- a/cmd/feature/root.go
+++ b/cmd/feature/root.go
@@ -44,7 +44,9 @@ func ensureRepo(cmd *cobra.Command, featureRoot string) error {
 	updateRepo, _ := cmd.Flags().GetBool("updateRepo")
 	if updateRepo {
 		args = []string{"pull"}
-		cerr := exec.Command(command, args...).Run()
+		pullCmd := exec.Command(command, args...)
+		pullCmd.Dir = featureRoot
+		cerr := pullCmd.Run()
 		if cerr != nil {
 			return cerr
 		}


### PR DESCRIPTION
In `cmd/feature/root.go:46-50`, the `git pull` command does not set its working directory to `featureRoot`. `exec.Command("git", "pull").Run()` executes in the process's current working directory, not in the cloned features repository. This means `git pull` will either fail or update the wrong repo.

Fix: set `cmd.Dir = featureRoot` on the `exec.Cmd` before calling `.Run()`, similar to how the clone command implicitly targets `featureRoot` via its arguments.

---
*Automated improvement by yeti improvement-identifier*