### PR TITLE
refactor: Sanitize shell values written to /etc/profile.d scripts

### DIFF
--- a/cmd/feature/root.go
+++ b/cmd/feature/root.go
@@ -9,10 +9,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 
 	"github.com/bketelsen/feature/internal/options"
 	"github.com/spf13/cobra"
 )
+
+// validEnvKey matches shell-safe environment variable names.
+var validEnvKey = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
 func checkRootUser(_ *cobra.Command) error {
 	if os.Geteuid() != 0 {
@@ -103,7 +107,10 @@ func updateEnvironment(_ *cobra.Command, opts options.FeatureOptions) error {
 		}
 		defer f.Close()
 		for k, v := range opts.ContainerEnv {
-			_, _ = fmt.Fprintf(f, "export %s=%s\n", k, v)
+			if !validEnvKey.MatchString(k) {
+				return fmt.Errorf("invalid environment variable name: %q", k)
+			}
+			_, _ = fmt.Fprintf(f, "export %s=%q\n", k, v)
 		}
 	}
 	return nil

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -67,7 +67,7 @@ Each feature has a `devcontainer-feature.json` parsed into `FeatureOptions` (see
 - `GetOptionsForPath(featureDir)` — for any feature directory (used by OCI path)
 
 ### Environment Persistence
-Container environment variables from feature metadata are written to `/etc/profile.d/devcontainer-{id}.sh` as `export KEY=VALUE` lines, making them available in new shell sessions.
+Container environment variables from feature metadata are written to `/etc/profile.d/devcontainer-{id}.sh` as `export KEY="VALUE"` lines (values are safely quoted via Go's `%q` verb), making them available in new shell sessions. Environment variable keys are validated to contain only alphanumeric characters and underscores to prevent shell injection.
 
 ### Configuration Layering
 Viper binds flags and environment variables with prefix `FEATURE_`. Dots and dashes in flag names are stripped for env var matching:


### PR DESCRIPTION
In `cmd/feature/root.go:105-107`, environment variable values from feature metadata are written directly into `/etc/profile.d/` shell scripts as `export KEY=VALUE` without any quoting. Since this tool runs as root and these profile scripts are sourced by all users' shells, a malicious or malformed `containerEnv` value (e.g., containing `$(command)` or `; rm -rf /`) would result in arbitrary command execution for every user who opens a shell.

Fix: quote the values when writing them, e.g., `fmt.Fprintf(f, "export %s=%q\n", k, v)` — Go's `%q` produces a safely-escaped double-quoted string. Additionally, validate that keys contain only alphanumeric characters and underscores to prevent key-side injection.

---
*Automated improvement by yeti improvement-identifier*