### PR TITLE
refactor: Fix broken viper flag binding (Flags vs PersistentFlags mismatch)

### DIFF
--- a/cmd/feature/main.go
+++ b/cmd/feature/main.go
@@ -122,9 +122,9 @@ func NewRootCommand() (*cobra.Command, *viper.Viper) {
 		},
 	}
 	rootCmd.Flags().StringP("featureRoot", "r", "~/.features", "Location to checkout feature repository")
-	_ = config.BindPFlag("featureRoot", rootCmd.PersistentFlags().Lookup("featureRoot"))
+	_ = config.BindPFlag("featureRoot", rootCmd.Flags().Lookup("featureRoot"))
 	rootCmd.Flags().BoolP("updateRepo", "u", false, "Update the feature repository")
-	_ = config.BindPFlag("updateRepo", rootCmd.PersistentFlags().Lookup("updateRepo"))
+	_ = config.BindPFlag("updateRepo", rootCmd.Flags().Lookup("updateRepo"))
 
 	return rootCmd, config
 }


### PR DESCRIPTION
In `cmd/feature/main.go:124-127`, flags are registered with `rootCmd.Flags()` (local flags) but bound to viper via `rootCmd.PersistentFlags().Lookup()`. Since these flags are not persistent, `PersistentFlags().Lookup("featureRoot")` and `PersistentFlags().Lookup("updateRepo")` both return `nil`, causing `BindPFlag` to silently do nothing. This means the `FEATURE_FEATUREROOT` and `FEATURE_UPDATEREPO` environment variables configured in `config.go` will never override the flag defaults.

Fix: change `rootCmd.PersistentFlags().Lookup(...)` to `rootCmd.Flags().Lookup(...)` on lines 125 and 127.

---
*Automated improvement by yeti improvement-identifier*